### PR TITLE
g4-common: thermal: massive thermal change (2/2)

### DIFF
--- a/configs/thermal-engine.conf
+++ b/configs/thermal-engine.conf
@@ -1,124 +1,69 @@
-[SS-BIG-CLUSTER]
+########################################################
+# This conf should be used to handle throttling ONLY
+# 2020 (c) steadfasterX
+#
+# HOTPLUG is handled by the kernel as a last resort
+# see: msm8992-lge.dtsi
+#
+# sensor: must match a valid sensor file or sensor alias
+# set_point:     trigger freq throttling, degrees * 1000
+# set_point_clr: stop throttling, degrees * 1000
+# algo_type:
+#	SS (Single Step),
+#	PID (Proportional-Integral-Derivative),
+#	monitor
+# sampling: time in MS (check/run interval)
+# debugging: outcomment the 'debug' flag,
+# 	     stop thermal-engine, start thermal-engine
+#	     also interesting:
+#	     thermal-engine -o > current.conf
+#	     ^^ this will show also the generated confs
+#		and some aliases for the field 'sensor'
+########################################################
+# defaults
+sampling 3000
+# enable debug by outcomment the following
+#debug
+
+# this has effect on the whole cluster
+# no single CPU handling is supported!
+[SS-LITTLE_CLUSTER]
 algo_type ss
 sampling 1000
-sensor quiet_therm
-device cluster1
-set_point 51000
-set_point_clr 48000
-device_max_limit 864000
-
-[SS-LITTLE-CLUSTER]
-algo_type ss
-sampling 1000
-sensor quiet_therm
-device cluster0
-set_point 54000
-set_point_clr 51000
-device_max_limit 787200
-
-[SS-POPMEM-BIG]
-algo_type ss
-sampling 10
-sensor pop_mem
-device cluster1
-set_point 80000
-set_point_clr 55000
-time_constant 16
-
-[SS-POPMEM-LITTLE]
-algo_type ss
-sampling 10
-sensor pop_mem
-device cluster0
-set_point 80000
-set_point_clr 55000
-time_constant 16
-
-[SS-GPU]
-algo_type ss
-sampling 250
-sensor gpu
-device gpu
-set_point 85000
-set_point_clr 55000
-time_constant 0
-
-[SS-CPU5]
-algo_type ss
-sampling 10
-sensor cpu5
-device cluster1
-set_point 85000
-set_point_clr 55000
-time_constant 0
-
-[SS-CPU4]
-algo_type ss
-sampling 10
-sensor cpu4
-device cluster1
-set_point 85000
-set_point_clr 55000
-time_constant 0
-
-[SS-CPU3]
-algo_type ss
-sampling 10
-sensor cpu3
-device cluster0
-set_point 85000
-set_point_clr 55000
-time_constant 0
-
-[SS-CPU2]
-algo_type ss
-sampling 10
-sensor cpu2
-device cluster0
-set_point 85000
-set_point_clr 55000
-time_constant 0
-
-[SS-CPU0-1]
-algo_type ss
-sampling 10
+# we do not have a valid sensor for the
+# cluster itself so we use the first one instead
 sensor cpu0-1
 device cluster0
-set_point 85000
-set_point_clr 55000
-time_constant 0
+set_point 75000
+set_point_clr 70000
 
-[HOTPLUG-CPU4]
-algo_type monitor
+# this has effect on the whole cluster
+# no single CPU handling is supported!
+[SS-BIG_CLUSTER]
+algo_type ss
 sampling 1000
+# we do not have a valid sensor for the
+# cluster itself so we use the first one instead
 sensor cpu4
-thresholds 52000
-thresholds_clr 49000
-actions hotplug_4
-action_info 1
-
-[HOTPLUG-CPU5]
-algo_type monitor
-sampling 1000
-sensor cpu5
-thresholds 50000
-thresholds_clr 47000
-actions hotplug_5
-action_info 1
+device cluster1
+set_point 85000
+set_point_clr 75000
 
 [GPU_MONITOR]
 algo_type monitor
-sensor quiet_therm
-sampling 1000
-thresholds 48000 49000 50000 51000 52000 53000
-thresholds_clr 47000 48000 49000 50000 51000 52000
+sensor gpu
+sampling 2500
+# the GPU can handle up to 70 C without any issues
+# so the following should avoid too much lagging
+thresholds 60000 64000 68000 72000
+thresholds_clr 57000 61000 65000 69000
 actions gpu gpu gpu gpu gpu gpu
-action_info 600000000 490000000 450000000 367000000 300000000 180000000
+action_info 600000000 490000000 367000000 180000000
 
 [BATTERY_MONITOR]
 algo_type monitor
-sampling 1000
-sensor quiet_therm
+sampling 5000
+sensor batt_therm
 thresholds 49000 54000 57000
 thresholds_clr 44000 49000 54000
 actions battery battery battery

--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -976,7 +976,7 @@ service thermal-engine /system/vendor/bin/thermal-engine
     socket thermal-recv-client stream 0660 root system
     socket thermal-recv-passive-client stream 0666 root system
     group root
-    disabled
+    writepid /dev/cpuset/system-background/tasks
 
 service per_mgr /system/vendor/bin/pm-service
     class core

--- a/thermal/thermal.c
+++ b/thermal/thermal.c
@@ -37,7 +37,7 @@
 #define BATTERY_SENSOR_NUM              1
 #define GPU_SENSOR_NUM                  12
 
-const int CPU_SENSORS[] = {8, 8, 9, 10, 13, 14};
+const int CPU_SENSORS[] = {7, 7, 9, 10, 13, 14};
 
 #define CPU_NUM                         (sizeof(CPU_SENSORS) / sizeof(int))
 #define TEMPERATURE_NUM                 9
@@ -45,7 +45,7 @@ const int CPU_SENSORS[] = {8, 8, 9, 10, 13, 14};
 // qcom, therm-reset-temp
 #define CPU_SHUTDOWN_THRESHOLD          115
 //qcom, limit-temp
-#define CPU_THROTTLING_THRESHOLD        60
+#define CPU_THROTTLING_THRESHOLD        112
 
 #define BATTERY_SHUTDOWN_THRESHOLD      60
 // vendor/lge/g4-common/proprietary/thermal-engine/thermal-engine-8992.conf


### PR DESCRIPTION
... part 1/2 = kernel.

TL;DR

Bringing back thermal-engine, fix and optimize everything around thermal based
frequency throttling and ensure device does not get HOT like HELL anymore.
The kernel handles hotplug of all cores if needed, while frequencies will be handled
by the thermal-engine service.

Details:

 - resurrect thermal-engine service (+ fix init)
 - fixing all useless and non-working thermal profiles (e.g. SS-CPU3 etc)
 - add and optimize cluster frequency handling
 - fix GPU monitor and optimizing frequency handling
 - fix Battery monitor
 - fix CPU_SENSORS (omg..)
 - fix all samplings

Explained:

The thermal-engine should (IMHO) not be used for hotplugging the cores. The kernel
is way more effective on that and the configuration there is optimized for the
LG G4.

On the other site handling frequency throttling on kernel level is not very flexible
and so you need the thermal-engine service for monitoring and handling that correctly.

If you still wanna use thermal-engine to handle hotplugging ensure you check the kernel
level first to avoid ping-pong between.

Signed-off-by: steadfasterX <steadfasterX@gmail.com>