### PR TITLE
g4-common: Disable swappiness (2/2)

### DIFF
--- a/rootdir/etc/sysctl.conf
+++ b/rootdir/etc/sysctl.conf
@@ -15,5 +15,3 @@ kernel.sched_freq_dec_notify = 400000
 vm.dirty_background_ratio = 70
 #echo 1000 > /proc/sys/vm/dirty_expire_centisecs
 vm.dirty_expire_centisecs = 1000
-#echo 10 > /proc/sys/vm/swappiness
-vm.swappiness = 0


### PR DESCRIPTION
As an extension to commit 820530d09afffdc1480dd0b24c57e0606dfb369f
totally remove swappiness after disabling it from kernel,
commit 3e65e03088f1ca20eb48d4f071dd9295d38833a8

Change-Id: I9bb87b3f2b401c94236afad911d3b4b7a5a0eacd