### PR TITLE
g4-common: Use legacy Wi-Fi service

### DIFF
--- a/g4.mk
+++ b/g4.mk
@@ -409,7 +409,7 @@ PRODUCT_PACKAGES += \
 
 # Wifi
 PRODUCT_PACKAGES += \
-    android.hardware.wifi@1.0-service \
+    android.hardware.wifi@1.0-service.legacy \
     libqsap_sdk \
     libQWiFiSoftApCfg \
     libwpa_client \


### PR DESCRIPTION
Otherwise Wi-Fi is broken in Q :-(

--------- switch to system
01-08 07:18:26.636   494   494 I android.hardware.wifi@1.0-service: Legacy HAL stop complete callback received
--------- switch to main
01-08 07:18:26.636   494   494 I WifiHAL : Internal cleanup completed
--------- switch to system
01-08 07:18:26.638   494   494 I android.hardware.wifi@1.0-service: Wifi HAL stopped
--------- switch to main
01-08 07:18:26.639  1162  1536 I WifiVendorHal: Vendor Hal stopped
01-08 07:18:26.640  1162  1536 D WifiClientModeManager: STA iface wlan0 was destroyed, stopping client mode
01-08 07:18:26.642  1162  1536 E SupplicantStaNetworkHal: ISupplicantStaNetwork.setBssid failed with exception
01-08 07:18:26.642  1162  1536 E SupplicantStaNetworkHal: android.os.RemoteException: HwBinder Error: (-32)
01-08 07:18:26.642  1162  1536 E SupplicantStaNetworkHal: at android.os.HwRemoteBinder.transact(Native Method)
01-08 07:18:26.642  1162  1536 E SupplicantStaNetworkHal: at android.hardware.wifi.supplicant.V1_0.ISupplicantStaNetwork$Proxy.setBssid(ISupplicantStaNetwork.java:2168)
01-08 07:18:26.642  1162  1536 E SupplicantStaNetworkHal: at com.android.server.wifi.SupplicantStaNetworkHal.setBssid(SupplicantStaNetworkHal.java:1231)
01-08 07:18:26.642  1162  1536 E SupplicantStaNetworkHal: at com.android.server.wifi.SupplicantStaNetworkHal.setBssid(SupplicantStaNetworkHal.java:1217)
01-08 07:18:26.642  1162  1536 E SupplicantStaNetworkHal: at com.android.server.wifi.SupplicantStaIfaceHal.setCurrentNetworkBssid(SupplicantStaIfaceHal.java:1019)
01-08 07:18:26.642  1162  1536 E SupplicantStaNetworkHal: at com.android.server.wifi.WifiNative.setConfiguredNetworkBSSID(WifiNative.java:2163)
01-08 07:18:26.642  1162  1536 E SupplicantStaNetworkHal: at com.android.server.wifi.ClientModeImpl.clearTargetBssid(ClientModeImpl.java:376)
01-08 07:18:26.642  1162  1536 E SupplicantStaNetworkHal: at com.android.server.wifi.ClientModeImpl.handleNetworkDisconnect(ClientModeImpl.java:2989)
01-08 07:18:26.642  1162  1536 E SupplicantStaNetworkHal: at com.android.server.wifi.ClientModeImpl.handleIfaceDestroyed(ClientModeImpl.java:1471)
01-08 07:18:26.642  1162  1536 E SupplicantStaNetworkHal: at com.android.server.wifi.ClientModeManager$ClientModeStateMachine$1.onDestroyed(ClientModeManager.java:180)
01-08 07:18:26.642  1162  1536 E SupplicantStaNetworkHal: at com.android.server.wifi.WifiNative.onInterfaceDestroyed(WifiNative.java:519)
01-08 07:18:26.642  1162  1536 E SupplicantStaNetworkHal: at com.android.server.wifi.WifiNative.access$1000(WifiNative.java:72)
01-08 07:18:26.642  1162  1536 E SupplicantStaNetworkHal: at com.android.server.wifi.WifiNative$InterfaceDestoyedListenerInternal.onDestroyed(WifiNative.java:546)
01-08 07:18:26.642  1162  1536 E SupplicantStaNetworkHal: at com.android.server.wifi.WifiVendorHal$StaInterfaceDestroyedListenerInternal.onDestroyed(WifiVendorHal.java:385)
01-08 07:18:26.642  1162  1536 E SupplicantStaNetworkHal: at com.android.server.wifi.HalDeviceManager$InterfaceDestroyedListenerProxy.action(HalDeviceManager.java:2105)
01-08 07:18:26.642  1162  1536 E SupplicantStaNetworkHal: at com.android.server.wifi.HalDeviceManager$ListenerProxy.trigger(HalDeviceManager.java:2070)
01-08 07:18:26.642  1162  1536 E SupplicantStaNetworkHal: at com.android.server.wifi.HalDeviceManager.dispatchDestroyedListeners(HalDeviceManager.java:2023)
01-08 07:18:26.642  1162  1536 E SupplicantStaNetworkHal: at com.android.server.wifi.HalDeviceManager.removeIfaceInternal(HalDeviceManager.java:1943)
01-08 07:18:26.642  1162  1536 E SupplicantStaNetworkHal: at com.android.server.wifi.HalDeviceManager.removeIface(HalDeviceManager.java:263)
01-08 07:18:26.642  1162  1536 E SupplicantStaNetworkHal: at com.android.server.wifi.WifiVendorHal.removeStaIface(WifiVendorHal.java:437)
01-08 07:18:26.642  1162  1536 E SupplicantStaNetworkHal: at com.android.server.wifi.WifiNative.removeStaIface(WifiNative.java:801)
01-08 07:18:26.642  1162  1536 E SupplicantStaNetworkHal: at com.android.server.wifi.WifiNative.teardownInterface(WifiNative.java:1135)
01-08 07:18:26.642  1162  1536 E SupplicantStaNetworkHal: at com.android.server.wifi.ClientModeManager$ClientModeStateMachine$StartedState.exit(ClientModeManager.java:322)
01-08 07:18:26.642  1162  1536 E SupplicantStaNetworkHal: at com.android.internal.util.StateMachine$SmHandler.invokeExitMethods(StateMachine.java:1021)
01-08 07:18:26.642  1162  1536 E SupplicantStaNetworkHal: at com.android.internal.util.StateMachine$SmHandler.performTransitions(StateMachine.java:877)
01-08 07:18:26.642  1162  1536 E SupplicantStaNetworkHal: at com.android.internal.util.StateMachine$SmHandler.handleMessage(StateMachine.java:819)
01-08 07:18:26.642  1162  1536 E SupplicantStaNetworkHal: at android.os.Handler.dispatchMessage(Handler.java:107)
01-08 07:18:26.642  1162  1536 E SupplicantStaNetworkHal: at android.os.Looper.loop(Looper.java:214)
01-08 07:18:26.642  1162  1536 E SupplicantStaNetworkHal: at android.os.HandlerThread.run(HandlerThread.java:67)
01-08 07:18:26.644  1162  1536 E SupplicantStaIfaceHal: Can't call setPowerSave, ISupplicantStaIface is null
01-08 07:18:26.645  1162  1536 E SupplicantStaIfaceHal: Can't call setBtCoexistenceMode, ISupplicantStaIface is null
01-08 07:18:26.648  1162  1536 I WifiNative: Successfully torn down Iface:{Name=wlan0,Id=0,Type=STA_CONNECTIVITY}
01-08 07:18:26.648  1162  1536 E HalDevMgr: getAllChipInfo: called but mWifi is null!?
01-08 07:18:26.649  1162  1536 E HalDevMgr: dispatchAvailableForRequestListeners: no chip info found
01-08 07:18:26.649  1162  1536 W HalDevMgr: stopWifi called but mWifi is null!?
01-08 07:18:26.649  1162  1536 I WifiNative: Successfully initiated teardown for iface=wlan0
01-08 07:18:26.650  1162  1537 W HalDevMgr: isWifiStarted called but mWifi is null!?
01-08 07:18:26.650  1162  1536 D WifiClientModeManager: expected stop, not triggering callbacks: newState = 1
01-08 07:18:26.652  1162  1162 D WifiP2pService: Wifi enabled=false, P2P Interface availability=true
01-08 07:18:26.652  1162  1536 D WifiOpenNetworkNotifier: Notification with state=1 was cleared for recommended network: "orange"

Change-Id: Ie264faa4740019f5cb4081e3b861ac9f3778923a
(cherry picked from commit a57052d25126c7a724586dc16fde33c74a7e0f69)